### PR TITLE
Add error handling to json parsing

### DIFF
--- a/src/refs.interceptor.ts
+++ b/src/refs.interceptor.ts
@@ -32,7 +32,11 @@ export class RefsInterceptor implements HttpInterceptor {
 
     static resolveReferences(json: any): any {
         if (typeof json === 'string') {
-            json = JSON.parse(json);
+            try {
+                json = JSON.parse(json);
+            } catch {
+                return json;
+            }   
         }
         const byid: any = {}; // all objects by id
         const refs: any[] = []; // references to objects that could not be resolved


### PR DESCRIPTION
This should fix the token error issue #4 by handling the error that comes up when parsing the token which is not in a correct JSON format.